### PR TITLE
Allow source to be optionally passed to parse()

### DIFF
--- a/refactorlib/parse.py
+++ b/refactorlib/parse.py
@@ -1,8 +1,9 @@
-def parse(filename, filetype=None, encoding=None):
+def parse(filename, filetype=None, encoding=None, source=None):
     from filetypes import FILETYPES
     filetype = FILETYPES.detect_filetype(filename, filetype)
 
-    source = open(filename).read()
+    if source is None:
+        source = open(filename).read()
 
     # If no encoding was explicitly specified, see if we can parse
     # it out from the contents of the file.

--- a/refactorlib/tests/parse_test.py
+++ b/refactorlib/tests/parse_test.py
@@ -1,0 +1,10 @@
+
+from refactorlib.parse import parse
+
+
+def test_parse_allows_you_to_explicitly_pass_source():
+    ret = parse('foo.py', source='foo()\n')
+    assert ret.tostring() == (
+        '<file_input><simple_stmt><power><NAME>foo</NAME><trailer><LPAR>(</LPAR><RPAR>)</RPAR></trailer></power><NEWLINE>\n'
+        '</NEWLINE></simple_stmt><ENDMARKER></ENDMARKER></file_input>'
+    )


### PR DESCRIPTION
I was hacking around this and basically reimplementing `parse` when using this, which felt gross.  This lets you still get the goodies of the encoding and filetype detector while allowing you to not need to reparse a file.

Also this makes it much easier to test stuff if you don't need a real file.
