### PR TITLE
mysteriously fix lucid

### DIFF
--- a/refactorlib/parse.py
+++ b/refactorlib/parse.py
@@ -46,7 +46,7 @@ def dictnode_to_lxml(tree, node_lookup=None, encoding=None):
             # to 'UTF8' if we use parser.makeelement()
             parser = XMLParser(encoding=encoding)
             parser.set_element_class_lookup(node_lookup)
-            parser.feed(b'<trash></trash>')
+            parser.feed(b'<a/>')
             lxmlnode = parser.close()
             lxmlnode.tag = node['name']
             lxmlnode.attrib.update(node.get('attrs', {}))


### PR DESCRIPTION
Otherwise it fails like this:

```python
>>> from lxml.etree import XMLParser
>>> XMLParser(encoding='UTF-8').feed(b'<trash/>')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "src/lxml/parser.pxi", line 1194, in lxml.etree._FeedParser.feed (src/lxml/lxml.etree.c:112022)
  File "src/lxml/parser.pxi", line 1316, in lxml.etree._FeedParser.feed (src/lxml/lxml.etree.c:111897)
  File "src/lxml/parser.pxi", line 564, in lxml.etree._ParserContext._handleParseResult (src/lxml/lxml.etree.c:103282)
  File "src/lxml/parser.pxi", line 573, in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/lxml.etree.c:103404)
  File "src/lxml/parser.pxi", line 683, in lxml.etree._handleParseResult (src/lxml/lxml.etree.c:105058)
  File "src/lxml/parser.pxi", line 613, in lxml.etree._raiseParseError (src/lxml/lxml.etree.c:103967)
lxml.etree.XMLSyntaxError: Extra content at the end of the document, line 1, column 9
```